### PR TITLE
Accelerate torch computations

### DIFF
--- a/src/vind/LinearModel/LinearModelDDL95.cc
+++ b/src/vind/LinearModel/LinearModelDDL95.cc
@@ -233,13 +233,13 @@ void LinearModelDDL95::tendencyTL(const Increment & dx,
             -view(jnode, jlevel);
 
           // X-direction diffusion
-          viewTen(jnode, jlevel) += nu_*(view(ixp1, jlevel)-2.0*view(jnode, jlevel)
-            +view(ixm1, jlevel));
+          viewTen(jnode, jlevel) += nu_*(view(ixp1, jlevel)+view(ixm1, jlevel)
+            -2.0*view(jnode, jlevel));
 
           // Y-direction diffusion
           if ((iy > iyMin_) && (iy < iyMax_)) {
-            viewTen(jnode, jlevel) += nu_*(view(iyp1, jlevel)-2.0*view(jnode, jlevel)
-              +view(iym1, jlevel));
+            viewTen(jnode, jlevel) += nu_*(view(iyp1, jlevel)+view(iym1, jlevel)
+              -2.0*view(jnode, jlevel));
           }
         }
       }
@@ -310,14 +310,14 @@ void LinearModelDDL95::tendencyAD(const Increment & dxTen,
 
           // X-direction diffusion
           view(ixp1, jlevel) += nu_*viewTen(jnode, jlevel);
-          view(jnode, jlevel) -= 2.0*nu_*viewTen(jnode, jlevel);
           view(ixm1, jlevel) += nu_*viewTen(jnode, jlevel);
+          view(jnode, jlevel) -= 2.0*nu_*viewTen(jnode, jlevel);
 
           // Y-direction diffusion
           if ((iy > iyMin_) && (iy < iyMax_)) {
             view(iyp1, jlevel) += nu_*viewTen(jnode, jlevel);
-            view(jnode, jlevel) -= 2.0*nu_*viewTen(jnode, jlevel);
             view(iym1, jlevel) += nu_*viewTen(jnode, jlevel);
+            view(jnode, jlevel) -= 2.0*nu_*viewTen(jnode, jlevel);
           }
         }
       }

--- a/src/vind/LinearModel/LinearModelNumPyDDL95.cc
+++ b/src/vind/LinearModel/LinearModelNumPyDDL95.cc
@@ -63,22 +63,6 @@ LinearModelNumPyDDL95::LinearModelNumPyDDL95(const Geometry & geom,
   (*params_)["nx"] = grid.nx();
   (*params_)["ny"] = grid.ny();
 
-  // Get computation zone boundaries
-  if (grid.periodic()) {
-    (*params_)["ixMin"] = 0;
-    (*params_)["ixMax"] = nx-1;
-  } else {
-    (*params_)["ixMin"] = 2;
-    (*params_)["ixMax"] = nx-2;
-  }
-  if (geom.gridType() == "regional") {
-    (*params_)["iyMin"] = 0;
-    (*params_)["iyMax"] = ny-1;
-  } else {
-    (*params_)["iyMin"] = 1;
-    (*params_)["iyMax"] = ny-2;
-  }
-
   // Define coordinates
   lonNArray_.reset(new pybind11::array_t<double>({ny, nx}));
   latNArray_.reset(new pybind11::array_t<double>({ny, nx}));
@@ -90,6 +74,42 @@ LinearModelNumPyDDL95::LinearModelNumPyDDL95(const Geometry & geom,
       const atlas::PointLonLat pointLonLat = grid.lonlat(jx, jy);
       lonNView(jy, jx) = pointLonLat.lon()*deg2rad;
       latNView(jy, jx) = pointLonLat.lat()*deg2rad;
+    }
+  }
+
+  // Compute masks
+  int ixMin, ixMax, iyMin, iyMax;
+  if (grid.periodic()) {
+    ixMin = 0;
+    ixMax = nx-1;
+  } else {
+    ixMin = 2;
+    ixMax = nx-2;
+  }
+  if (geom.gridType() == "regional") {
+    iyMin = 0;
+    iyMax = ny-1;
+  } else {
+    iyMin = 1;
+    iyMax = ny-2;
+  }
+  cMaskNArray_.reset(new pybind11::array_t<double>({ny, nx}));
+  yMaskNArray_.reset(new pybind11::array_t<double>({ny, nx}));
+  (*cMaskNArray_)[pybind11::make_tuple(pybind11::ellipsis())] = 0.0;
+  (*yMaskNArray_)[pybind11::make_tuple(pybind11::ellipsis())] = 0.0;
+  auto cMaskNView = cMaskNArray_->mutable_unchecked<2>();
+  auto yMaskNView = yMaskNArray_->mutable_unchecked<2>();
+  for (int jx = 0; jx < nx; ++jx) {
+    for (int jy = 0; jy < ny; ++jy) {
+      if ((jx >= ixMin) && (jx <= ixMax) && (jy >= iyMin) && (jy <= iyMax)) {
+        // Inside computation zone
+        cMaskNView(jy, jx) = 1.0;
+
+        if ((jy > iyMin) && (jy < iyMax)) {
+          // Y-direction diffusion
+          yMaskNView(jy, jx) = 1.0;
+        }
+      }
     }
   }
 
@@ -185,8 +205,8 @@ void LinearModelNumPyDDL95::stepTL(Increment & dx,
     pybind11::module_ exec = pybind11::module_::import(moduleName.c_str());
 
     // Execute time step
-    pybind11::object result = exec.attr("stepTL")(*params_, *lonNArray_, *latNArray_, t,
-      trajNArray, incrNArray);
+    pybind11::object result = exec.attr("stepTL")(*params_, *lonNArray_, *latNArray_, *cMaskNArray_,
+      *yMaskNArray_, t, trajNArray, incrNArray);
 
     // Copy data from numpy array
     for (int jnode = 0; jnode < globalIncr.shape(0); ++jnode) {
@@ -269,8 +289,8 @@ void LinearModelNumPyDDL95::stepAD(Increment & dx,
     pybind11::module_ exec = pybind11::module_::import(moduleName.c_str());
 
     // Execute time step
-    pybind11::object result = exec.attr("stepAD")(*params_, *lonNArray_, *latNArray_, t,
-      trajNArray, incrNArray);
+    pybind11::object result = exec.attr("stepAD")(*params_, *lonNArray_, *latNArray_, *cMaskNArray_,
+      *yMaskNArray_, t, trajNArray, incrNArray);
 
     // Copy data from numpy array
     for (int jnode = 0; jnode < globalIncr.shape(0); ++jnode) {

--- a/src/vind/LinearModel/LinearModelNumPyDDL95.h
+++ b/src/vind/LinearModel/LinearModelNumPyDDL95.h
@@ -90,6 +90,8 @@ class __attribute__((visibility("hidden"))) LinearModelNumPyDDL95:
   std::unique_ptr<pybind11::dict> params_;
   std::unique_ptr<pybind11::array_t<double>> lonNArray_;
   std::unique_ptr<pybind11::array_t<double>> latNArray_;
+  std::unique_ptr<pybind11::array_t<double>> cMaskNArray_;
+  std::unique_ptr<pybind11::array_t<double>> yMaskNArray_;
   std::map<util::DateTime, State> traj_;
 };
 // -----------------------------------------------------------------------------

--- a/src/vind/LinearModel/LinearModelPyTorchDDL95.cc
+++ b/src/vind/LinearModel/LinearModelPyTorchDDL95.cc
@@ -63,22 +63,6 @@ LinearModelTorchPyDDL95::LinearModelTorchPyDDL95(const Geometry & geom,
   (*params_)["nx"] = grid.nx();
   (*params_)["ny"] = grid.ny();
 
-  // Get computation zone boundaries
-  if (grid.periodic()) {
-    (*params_)["ixMin"] = 0;
-    (*params_)["ixMax"] = nx-1;
-  } else {
-    (*params_)["ixMin"] = 2;
-    (*params_)["ixMax"] = nx-2;
-  }
-  if (geom.gridType() == "regional") {
-    (*params_)["iyMin"] = 0;
-    (*params_)["iyMax"] = ny-1;
-  } else {
-    (*params_)["iyMin"] = 1;
-    (*params_)["iyMax"] = ny-2;
-  }
-
   // Define tensor options
   opts_ = torch::TensorOptions()
     .dtype(torch::kFloat64)
@@ -97,6 +81,40 @@ LinearModelTorchPyDDL95::LinearModelTorchPyDDL95(const Geometry & geom,
       const atlas::PointLonLat pointLonLat = grid.lonlat(jx, jy);
       lonTView[jy][jx] = pointLonLat.lon()*deg2rad;
       latTView[jy][jx] = pointLonLat.lat()*deg2rad;
+    }
+  }
+
+  // Compute masks
+  int ixMin, ixMax, iyMin, iyMax;
+  if (grid.periodic()) {
+    ixMin = 0;
+    ixMax = nx-1;
+  } else {
+    ixMin = 2;
+    ixMax = nx-2;
+  }
+  if (geom.gridType() == "regional") {
+    iyMin = 0;
+    iyMax = ny-1;
+  } else {
+    iyMin = 1;
+    iyMax = ny-2;
+  }
+  cMaskTTensor_ = torch::zeros({ny, nx}, opts_);
+  yMaskTTensor_ = torch::zeros({ny, nx}, opts_);
+  auto cMaskTView = cMaskTTensor_.accessor<double, 2>();
+  auto yMaskTView = yMaskTTensor_.accessor<double, 2>();
+  for (int jx = 0; jx < nx; ++jx) {
+    for (int jy = 0; jy < ny; ++jy) {
+      if ((jx >= ixMin) && (jx <= ixMax) && (jy >= iyMin) & (jy <= iyMax)) {
+        // Inside computation zone
+        cMaskTView[jy][jx] = 1.0;
+
+        if ((jy > iyMin) && (jy < iyMax)) {
+          // Y-direction diffusion
+          yMaskTView[jy][jx] = 1.0;
+        }
+      }
     }
   }
 
@@ -192,8 +210,8 @@ void LinearModelTorchPyDDL95::stepTL(Increment & dx,
     pybind11::module_ exec = pybind11::module_::import(moduleName.c_str());
 
     // Execute time step
-    pybind11::object result = exec.attr("stepTL")(*params_, lonTTensor_, latTTensor_, t,
-      trajTTensor, incrTTensor);
+    pybind11::object result = exec.attr("stepTL")(*params_, lonTTensor_, latTTensor_, cMaskTTensor_,
+      yMaskTTensor_, t, trajTTensor, incrTTensor);
 
     // Copy data from numpy array
     for (int jnode = 0; jnode < globalIncr.shape(0); ++jnode) {
@@ -276,8 +294,8 @@ void LinearModelTorchPyDDL95::stepAD(Increment & dx,
     pybind11::module_ exec = pybind11::module_::import(moduleName.c_str());
 
     // Execute time step
-    pybind11::object result = exec.attr("stepAD")(*params_, lonTTensor_, latTTensor_, t,
-      trajTTensor, incrTTensor);
+    pybind11::object result = exec.attr("stepAD")(*params_, lonTTensor_, latTTensor_, cMaskTTensor_,
+      yMaskTTensor_, t, trajTTensor, incrTTensor);
 
     // Copy data from numpy array
     for (int jnode = 0; jnode < globalIncr.shape(0); ++jnode) {

--- a/src/vind/LinearModel/LinearModelPyTorchDDL95.h
+++ b/src/vind/LinearModel/LinearModelPyTorchDDL95.h
@@ -92,6 +92,8 @@ class __attribute__((visibility("hidden"))) LinearModelTorchPyDDL95:
   torch::TensorOptions opts_;
   torch::Tensor lonTTensor_;
   torch::Tensor latTTensor_;
+  torch::Tensor cMaskTTensor_;
+  torch::Tensor yMaskTTensor_;
   std::map<util::DateTime, State> traj_;
 };
 // -----------------------------------------------------------------------------

--- a/src/vind/Model/ModelDDL95.cc
+++ b/src/vind/Model/ModelDDL95.cc
@@ -34,7 +34,17 @@ ModelDDL95::ModelDDL95(const Geometry & geom,
   nx_ = grid.nx();
   ny_ = grid.ny();
 
-  // Get computation zone boundaries
+  // Define x/y coordinates
+  const atlas::functionspace::StructuredColumns fs(geom.functionSpace());
+  lonLatField_ = fs.xy().clone();
+  auto lonlatView = atlas::array::make_view<double, 2>(lonLatField_);
+  const double deg2rad = M_PI/180.0;
+  for (int jnode = 0; jnode < lonLatField_.shape(0); ++jnode) {
+    lonlatView(jnode, 0) *= deg2rad;
+    lonlatView(jnode, 1) *= deg2rad;
+  }
+
+  // Get mask boundaries
   if (grid.periodic()) {
     ixMin_ = 0;
     ixMax_ = nx_-1;
@@ -48,16 +58,6 @@ ModelDDL95::ModelDDL95(const Geometry & geom,
   } else {
     iyMin_ = 1;
     iyMax_ = ny_-2;
-  }
-
-  // Define x/y coordinates
-  const atlas::functionspace::StructuredColumns fs(geom.functionSpace());
-  lonLatField_ = fs.xy().clone();
-  auto lonlatView = atlas::array::make_view<double, 2>(lonLatField_);
-  const double deg2rad = M_PI/180.0;
-  for (int jnode = 0; jnode < lonLatField_.shape(0); ++jnode) {
-    lonlatView(jnode, 0) *= deg2rad;
-    lonlatView(jnode, 1) *= deg2rad;
   }
 
   // Internal time-step

--- a/src/vind/Model/ModelDDL95.cc
+++ b/src/vind/Model/ModelDDL95.cc
@@ -164,13 +164,13 @@ void ModelDDL95::tendency(const State & xx,
             -view(jnode, jlevel)+FF;
 
           // X-direction diffusion
-          viewTen(jnode, jlevel) += nu_*(view(ixp1, jlevel)-2.0*view(jnode, jlevel)
-            +view(ixm1, jlevel));
+          viewTen(jnode, jlevel) += nu_*(view(ixp1, jlevel)+view(ixm1, jlevel)
+            -2.0*view(jnode, jlevel));
 
           // Y-direction diffusion
           if ((iy > iyMin_) && (iy < iyMax_)) {
-           viewTen(jnode, jlevel) += nu_*(view(iyp1, jlevel)-2.0*view(jnode, jlevel)
-             +view(iym1, jlevel));
+           viewTen(jnode, jlevel) += nu_*(view(iyp1, jlevel)+view(iym1, jlevel)
+             -2.0*view(jnode, jlevel));
           }
         }
       }

--- a/src/vind/Model/ModelDDL95.h
+++ b/src/vind/Model/ModelDDL95.h
@@ -69,11 +69,11 @@ class ModelDDL95: public ModelBase,
   const double nu_ = 1.0;
   size_t nx_;
   size_t ny_;
+  atlas::Field lonLatField_;
   size_t ixMin_;
   size_t ixMax_;
   size_t iyMin_;
   size_t iyMax_;
-  atlas::Field lonLatField_;
   double dti_;
   util::Duration dt_half_;
 };

--- a/src/vind/Model/ModelNumPyDDL95.cc
+++ b/src/vind/Model/ModelNumPyDDL95.cc
@@ -63,22 +63,6 @@ ModelNumPyDDL95::ModelNumPyDDL95(const Geometry & geom,
   (*params_)["nx"] = grid.nx();
   (*params_)["ny"] = grid.ny();
 
-  // Get computation zone boundaries
-  if (grid.periodic()) {
-    (*params_)["ixMin"] = 0;
-    (*params_)["ixMax"] = nx-1;
-  } else {
-    (*params_)["ixMin"] = 2;
-    (*params_)["ixMax"] = nx-2;
-  }
-  if (geom.gridType() == "regional") {
-    (*params_)["iyMin"] = 0;
-    (*params_)["iyMax"] = ny-1;
-  } else {
-    (*params_)["iyMin"] = 1;
-    (*params_)["iyMax"] = ny-2;
-  }
-
   // Define coordinates
   lonNArray_.reset(new pybind11::array_t<double>({ny, nx}));
   latNArray_.reset(new pybind11::array_t<double>({ny, nx}));
@@ -90,6 +74,42 @@ ModelNumPyDDL95::ModelNumPyDDL95(const Geometry & geom,
       const atlas::PointLonLat pointLonLat = grid.lonlat(jx, jy);
       lonNView(jy, jx) = pointLonLat.lon()*deg2rad;
       latNView(jy, jx) = pointLonLat.lat()*deg2rad;
+    }
+  }
+
+  // Compute masks
+  int ixMin, ixMax, iyMin, iyMax;
+  if (grid.periodic()) {
+    ixMin = 0;
+    ixMax = nx-1;
+  } else {
+    ixMin = 2;
+    ixMax = nx-2;
+  }
+  if (geom.gridType() == "regional") {
+    iyMin = 0;
+    iyMax = ny-1;
+  } else {
+    iyMin = 1;
+    iyMax = ny-2;
+  }
+  cMaskNArray_.reset(new pybind11::array_t<double>({ny, nx}));
+  yMaskNArray_.reset(new pybind11::array_t<double>({ny, nx}));
+  (*cMaskNArray_)[pybind11::make_tuple(pybind11::ellipsis())] = 0.0;
+  (*yMaskNArray_)[pybind11::make_tuple(pybind11::ellipsis())] = 0.0;
+  auto cMaskNView = cMaskNArray_->mutable_unchecked<2>();
+  auto yMaskNView = yMaskNArray_->mutable_unchecked<2>();
+  for (int jx = 0; jx < nx; ++jx) {
+    for (int jy = 0; jy < ny; ++jy) {
+      if ((jx >= ixMin) && (jx <= ixMax) && (jy >= iyMin) && (jy <= iyMax)) {
+        // Inside computation zone
+        cMaskNView(jy, jx) = 1.0;
+
+        if ((jy > iyMin) && (jy < iyMax)) {
+          // Y-direction diffusion
+          yMaskNView(jy, jx) = 1.0;
+        }
+      }
     }
   }
 
@@ -165,8 +185,8 @@ void ModelNumPyDDL95::step(State & xx,
     pybind11::module_ exec = pybind11::module_::import(moduleName.c_str());
 
     // Execute time step
-    pybind11::object result = exec.attr("step")(*params_, *lonNArray_, *latNArray_, t,
-      stateNumpyArray);
+    pybind11::object result = exec.attr("step")(*params_, *lonNArray_, *latNArray_, *cMaskNArray_,
+      *yMaskNArray_, t, stateNumpyArray);
 
     // Copy data from numpy array
     for (int jnode = 0; jnode < globalState.shape(0); ++jnode) {

--- a/src/vind/Model/ModelNumPyDDL95.h
+++ b/src/vind/Model/ModelNumPyDDL95.h
@@ -67,6 +67,8 @@ class __attribute__((visibility("hidden"))) ModelNumPyDDL95:
   std::unique_ptr<pybind11::dict> params_;
   std::unique_ptr<pybind11::array_t<double>> lonNArray_;
   std::unique_ptr<pybind11::array_t<double>> latNArray_;
+  std::unique_ptr<pybind11::array_t<double>> cMaskNArray_;
+  std::unique_ptr<pybind11::array_t<double>> yMaskNArray_;
 };
 // -----------------------------------------------------------------------------
 

--- a/src/vind/Model/ModelPyTorchDDL95.cc
+++ b/src/vind/Model/ModelPyTorchDDL95.cc
@@ -63,22 +63,6 @@ ModelPyTorchDDL95::ModelPyTorchDDL95(const Geometry & geom,
   (*params_)["nx"] = grid.nx();
   (*params_)["ny"] = grid.ny();
 
-  // Get computation zone boundaries
-  if (grid.periodic()) {
-    (*params_)["ixMin"] = 0;
-    (*params_)["ixMax"] = nx-1;
-  } else {
-    (*params_)["ixMin"] = 2;
-    (*params_)["ixMax"] = nx-2;
-  }
-  if (geom.gridType() == "regional") {
-    (*params_)["iyMin"] = 0;
-    (*params_)["iyMax"] = ny-1;
-  } else {
-    (*params_)["iyMin"] = 1;
-    (*params_)["iyMax"] = ny-2;
-  }
-
   // Define tensor options
   opts_ = torch::TensorOptions()
     .dtype(torch::kFloat64)
@@ -97,6 +81,40 @@ ModelPyTorchDDL95::ModelPyTorchDDL95(const Geometry & geom,
       const atlas::PointLonLat pointLonLat = grid.lonlat(jx, jy);
       lonTView[jy][jx] = pointLonLat.lon()*deg2rad;
       latTView[jy][jx] = pointLonLat.lat()*deg2rad;
+    }
+  }
+
+  // Compute masks
+  int ixMin, ixMax, iyMin, iyMax;
+  if (grid.periodic()) {
+    ixMin = 0;
+    ixMax = nx-1;
+  } else {
+    ixMin = 2;
+    ixMax = nx-2;
+  }
+  if (geom.gridType() == "regional") {
+    iyMin = 0;
+    iyMax = ny-1;
+  } else {
+    iyMin = 1;
+    iyMax = ny-2;
+  }
+  cMaskTTensor_ = torch::zeros({ny, nx}, opts_);
+  yMaskTTensor_ = torch::zeros({ny, nx}, opts_);
+  auto cMaskTView = cMaskTTensor_.accessor<double, 2>();
+  auto yMaskTView = yMaskTTensor_.accessor<double, 2>();
+  for (int jx = 0; jx < nx; ++jx) {
+    for (int jy = 0; jy < ny; ++jy) {
+      if ((jx >= ixMin) && (jx <= ixMax) && (jy >= iyMin) && (jy <= iyMax)) {
+        // Inside computation zone
+        cMaskTView[jy][jx] = 1.0;
+
+        if ((jy > iyMin) && (jy < iyMax)) {
+          // Y-direction diffusion
+          yMaskTView[jy][jx] = 1.0;
+        }
+      }
     }
   }
 
@@ -172,8 +190,8 @@ void ModelPyTorchDDL95::step(State & xx,
     pybind11::module_ exec = pybind11::module_::import(moduleName.c_str());
 
     // Execute time step
-    pybind11::object result = exec.attr("step")(*params_, lonTTensor_, latTTensor_, t,
-      stateTTensor);
+    pybind11::object result = exec.attr("step")(*params_, lonTTensor_, latTTensor_, cMaskTTensor_,
+      yMaskTTensor_, t, stateTTensor);
 
     // Copy data from torch tensor
     for (int jnode = 0; jnode < globalState.shape(0); ++jnode) {

--- a/src/vind/Model/ModelPyTorchDDL95.h
+++ b/src/vind/Model/ModelPyTorchDDL95.h
@@ -69,6 +69,8 @@ class __attribute__((visibility("hidden"))) ModelPyTorchDDL95:
   torch::TensorOptions opts_;
   torch::Tensor lonTTensor_;
   torch::Tensor latTTensor_;
+  torch::Tensor cMaskTTensor_;
+  torch::Tensor yMaskTTensor_;
 };
 // -----------------------------------------------------------------------------
 

--- a/src/vind/Python/NumPyDDL95.py
+++ b/src/vind/Python/NumPyDDL95.py
@@ -6,25 +6,21 @@
 
 import numpy as np
 
-def step(params, lon, lat, t, xx):
+def step(params, lon, lat, cMask, yMask, t, xx):
   # Integration parameters
   dt = params["dt"]
   dti = params["dti"]
 
   # First step
-  xxTmp = xx+tendency(params, lon, lat, t, xx)*0.5*dti
+  xxTmp = xx+tendency(params, lon, lat, cMask, yMask, t, xx)*0.5*dti
 
   # Second step
-  xx += tendency(params, lon, lat, t+0.5*dt, xxTmp)*dti
+  xx += tendency(params, lon, lat, cMask, yMask, t+0.5*dt, xxTmp)*dti
 
-def tendency(params, lon, lat, t, xx):
+def tendency(params, lon, lat, cMask, yMask, t, xx):
   # Parameters
   nx = params["nx"]
   ny = params["ny"]
-  ixMin = params["ixMin"]
-  ixMax = params["ixMax"]
-  iyMin = params["iyMin"]
-  iyMax = params["iyMax"]
   F = params["F"]
   omega = params["omega"]
   nu = params["nu"]
@@ -43,56 +39,45 @@ def tendency(params, lon, lat, t, xx):
   # Create tendency
   xxTen = np.zeros((nz,ny,nx))
 
-  for jy in range(ny):
-    for jx in range(nx):
-      if jx >= ixMin and jx <= ixMax and jy >= iyMin and jy <= iyMax:
-        # Inside computation zone
+  # Time-dependent forcing
+  FF = np.tile((1.0+0.4*np.sin(lon-omega*t)*np.cos(lat))*F, (nz, 1, 1))
 
-        # Retrieve array indices
-        ixp1 = (jx+1)%nx
-        ixm2 = (jx-2)%nx
-        ixm1 = (jx-1)%nx
-        iyp1 = jy+1
-        iym1 = jy-1
+  # Shift state
+  xx_xp1 = np.roll(xx, shift=(-1), axis=(2))
+  xx_xm1 = np.roll(xx, shift=(1), axis=(2))
+  xx_xm2 = np.roll(xx, shift=(2), axis=(2))
+  xx_yp1 = np.roll(xx, shift=(-1), axis=(1))
+  xx_ym1 = np.roll(xx, shift=(1), axis=(1))
 
-        # Time-dependent forcing
-        FF = (1.0+0.4*np.sin(lon[jy,jx]-omega*t)*np.cos(lat[jy,jx]))*F
+  # Usual L95 in x direction
+  xxTen = ((xx_xp1-xx_xm2)*xx_xm1-xx+FF)*cMask
 
-        for jz in range(nz):
-          # Usual L95 in x direction
-          xxTen[jz,jy,jx] = (xx[jz,jy,ixp1]-xx[jz,jy,ixm2])*xx[jz,jy,ixm1]-xx[jz,jy,jx]+FF
+  # Diffusion in x direction
+  xxTen += nu*(xx_xp1+xx_xm1-2.0*xx)*cMask
 
-          # X-direction diffusion
-          xxTen[jz,jy,jx] += nu*(xx[jz,jy,ixp1]-2.0*xx[jz,jy,jx]+xx[jz,jy,ixm1])
-
-          # Y-direction diffusion
-          if jy > iyMin and jy < iyMax:
-            xxTen[jz,jy,jx] += nu*(xx[jz,iyp1,jx]-2.0*xx[jz,jy,jx]+xx[jz,iym1,jx])
+  # Diffusion in y direction
+  xxTen += nu*(xx_yp1+xx_ym1-2.0*xx)*yMask
 
   return xxTen
 
-def stepTL(params, lon, lat, t, xxTraj, dx):
+def stepTL(params, lon, lat, cMask, yMask, t, xxTraj, dx):
   # Integration parameters
   dt = params["dt"]
   dti = params["dti"]
 
   # Compute intermediate trajectory state
-  xxTrajTmp = xxTraj+tendency(params, lon, lat, t, xxTraj)*0.5*dti
+  xxTrajTmp = xxTraj+tendency(params, lon, lat, cMask, yMask, t, xxTraj)*0.5*dti
 
   # First step
-  dxTmp = dx+tendencyTL(params, xxTraj, dx)*0.5*dti
+  dxTmp = dx+tendencyTL(params, cMask, yMask, xxTraj, dx)*0.5*dti
 
   # Second step
-  dx += tendencyTL(params, xxTrajTmp, dxTmp)*dti
+  dx += tendencyTL(params, cMask, yMask, xxTrajTmp, dxTmp)*dti
 
-def tendencyTL(params, xxTraj, dx):
+def tendencyTL(params, cMask, yMask, xxTraj, dx):
   # Parameters
   nx = params["nx"]
   ny = params["ny"]
-  ixMin = params["ixMin"]
-  ixMax = params["ixMax"]
-  iyMin = params["iyMin"]
-  iyMax = params["iyMax"]
   nu = params["nu"]
 
   # Number of levels
@@ -109,54 +94,50 @@ def tendencyTL(params, xxTraj, dx):
   # Create tendency
   dxTen = np.zeros((nz,ny,nx))
 
-  for jx in range(nx):
-    for jy in range(ny):
-      if jx >= ixMin and jx <= ixMax and jy >= iyMin and jy <= iyMax:
-        # Inside computation zone
+  # Shift trajectory
+  xxTraj_xp1 = np.roll(xxTraj, shift=(-1), axis=(2))
+  xxTraj_xm1 = np.roll(xxTraj, shift=(1), axis=(2))
+  xxTraj_xm2 = np.roll(xxTraj, shift=(2), axis=(2))
+  xxTraj_yp1 = np.roll(xxTraj, shift=(-1), axis=(1))
+  xxTraj_ym1 = np.roll(xxTraj, shift=(1), axis=(1))
 
-        # Retrieve array indices
-        ixp1 = (jx+1)%nx
-        ixm2 = (jx-2)%nx
-        ixm1 = (jx-1)%nx
-        iyp1 = jy+1
-        iym1 = jy-1
+  # Shift increment
+  dx_xp1 = np.roll(dx, shift=(-1), axis=(2))
+  dx_xm1 = np.roll(dx, shift=(1), axis=(2))
+  dx_xm2 = np.roll(dx, shift=(2), axis=(2))
+  dx_yp1 = np.roll(dx, shift=(-1), axis=(1))
+  dx_ym1 = np.roll(dx, shift=(1), axis=(1))
 
-        for jz in range(nz):
-          # Usual L95 in x direction
-          dxTen[jz,jy,jx] = (dx[jz,jy,ixp1]-dx[jz,jy,ixm2])*xxTraj[jz,jy,ixm1]+(xxTraj[jz,jy,ixp1]-xxTraj[jz,jy,ixm2])*dx[jz,jy,ixm1]-dx[jz,jy,jx]
+  # Usual L95 in x direction
+  dxTen = ((dx_xp1-dx_xm2)*xxTraj_xm1+(xxTraj_xp1-xxTraj_xm2)*dx_xm1-dx)*cMask
 
-          # X-direction diffusion
-          dxTen[jz,jy,jx] += nu*(dx[jz,jy,ixp1]-2.0*dx[jz,jy,jx]+dx[jz,jy,ixm1])
+  # X-direction diffusion
+  dxTen += nu*(dx_xp1+dx_xm1-2.0*dx)*cMask
 
-          # Y-direction diffusion
-          if jy > iyMin and jy < iyMax:
-            dxTen[jz,jy,jx] += nu*(dx[jz,iyp1,jx]-2.0*dx[jz,jy,jx]+dx[jz,iym1,jx])
+  # Y-direction diffusion
+  dxTen += nu*(dx_yp1+dx_ym1-2.0*dx)*yMask
 
   return dxTen
 
-def stepAD(params, lon, lat, t, xxTraj, dx):
+def stepAD(params, lon, lat, cMask, yMask, t, xxTraj, dx):
   # Integration parameters
   dt = params["dt"]
   dti = params["dti"]
 
   # Compute intermediate trajectory state
-  xxTrajTmp = xxTraj+tendency(params, lon, lat, t, xxTraj)*0.5*dti
+  xxTrajTmp = xxTraj+tendency(params, lon, lat, cMask, yMask, t, xxTraj)*0.5*dti
 
   # Second step
-  dxTmp = tendencyAD(params, xxTrajTmp, dx*dti)
+  dxTmp = tendencyAD(params, cMask, yMask, xxTrajTmp, dx*dti)
   dx += dxTmp
 
   # First step
-  dx += tendencyAD(params, xxTraj, dxTmp*0.5*dti)
+  dx += tendencyAD(params, cMask, yMask, xxTraj, dxTmp*0.5*dti)
 
-def tendencyAD(params, xxTraj, dxTen):
+def tendencyAD(params, cMask, yMask, xxTraj, dxTen):
   # Parameters
   nx = params["nx"]
   ny = params["ny"]
-  ixMin = params["ixMin"]
-  ixMax = params["ixMax"]
-  iyMin = params["iyMin"]
-  iyMax = params["iyMax"]
   nu = params["nu"]
 
   # Number of levels
@@ -170,37 +151,44 @@ def tendencyAD(params, xxTraj, dxTen):
     print("inconsistent nx dimension")
     exit(1)
 
-  # Create tendency
+  # Create increment
   dx = np.zeros((nz,ny,nx))
 
-  for jx in range(nx):
-    for jy in range(ny):
-      if jx >= ixMin and jx <= ixMax and jy >= iyMin and jy <= iyMax:
-        # Inside computation zone
+  # Shift trajectory
+  xxTraj_xp1 = np.roll(xxTraj, shift=(-1), axis=(2))
+  xxTraj_xm1 = np.roll(xxTraj, shift=(1), axis=(2))
+  xxTraj_xm2 = np.roll(xxTraj, shift=(2), axis=(2))
+  xxTraj_yp1 = np.roll(xxTraj, shift=(-1), axis=(1))
+  xxTraj_ym1 = np.roll(xxTraj, shift=(1), axis=(1))
 
-        # Retrieve array indices
-        ixp1 = (jx+1)%nx
-        ixm2 = (jx-2)%nx
-        ixm1 = (jx-1)%nx
-        iyp1 = jy+1
-        iym1 = jy-1
+  # Create shifted increments
+  dx_xp1 = np.zeros((nz,ny,nx))
+  dx_xm1 = np.zeros((nz,ny,nx))
+  dx_xm2 = np.zeros((nz,ny,nx))
+  dx_yp1 = np.zeros((nz,ny,nx))
+  dx_ym1 = np.zeros((nz,ny,nx))
 
-        for jz in range(nz):
-          # Usual L95 in x direction
-          dx[jz,jy,ixp1] += dxTen[jz,jy,jx]*xxTraj[jz,jy,ixm1]
-          dx[jz,jy,ixm2] -= dxTen[jz,jy,jx]*xxTraj[jz,jy,ixm1]
-          dx[jz,jy,ixm1] += dxTen[jz,jy,jx]*(xxTraj[jz,jy,ixp1]-xxTraj[jz,jy,ixm2])
-          dx[jz,jy,jx] -= dxTen[jz,jy,jx]
+  # Usual L95 in x direction
+  dx_xp1 += dxTen*xxTraj_xm1*cMask
+  dx_xm2 -= dxTen*xxTraj_xm1*cMask
+  dx_xm1 += dxTen*(xxTraj_xp1-xxTraj_xm2)*cMask
+  dx -= dxTen*cMask
 
-          # X-direction diffusion
-          dx[jz,jy,ixp1] += nu*dxTen[jz,jy,jx]
-          dx[jz,jy,jx] -= 2.0*nu*dxTen[jz,jy,jx]
-          dx[jz,jy,ixm1] += nu*dxTen[jz,jy,jx]
+  # X-direction diffusion
+  dx_xp1 += nu*dxTen*cMask
+  dx_xm1 += nu*dxTen*cMask
+  dx -= 2.0*nu*dxTen*cMask
 
-          # Y-direction diffusion
-          if jy > iyMin and jy < iyMax:
-            dx[jz,iyp1,jx] += nu*dxTen[jz,jy,jx]
-            dx[jz,jy,jx] -= 2.0*nu*dxTen[jz,jy,jx]
-            dx[jz,iym1,jx] += nu*dxTen[jz,jy,jx]
+  # Y-direction diffusion
+  dx_yp1 += nu*dxTen*yMask
+  dx_ym1 += nu*dxTen*yMask
+  dx -= 2.0*nu*dxTen*yMask
+
+  # Un-shift and accumulate shifted increments
+  dx += np.roll(dx_xp1, shift=(1), axis=(2))
+  dx += np.roll(dx_xm1, shift=(-1), axis=(2))
+  dx += np.roll(dx_xm2, shift=(-2), axis=(2))
+  dx += np.roll(dx_yp1, shift=(1), axis=(1))
+  dx += np.roll(dx_ym1, shift=(-1), axis=(1))
 
   return dx

--- a/src/vind/Python/PyTorchDDL95.py
+++ b/src/vind/Python/PyTorchDDL95.py
@@ -6,44 +6,21 @@
 
 import torch
 
-def step(params, lon, lat, t, xx):
+def step(params, lon, lat, cMask, yMask, t, xx):
   # Integration parameters
   dt = params["dt"]
   dti = params["dti"]
 
   # First step
-  xxTmp = xx+tendency(params, lon, lat, t, xx)*0.5*dti
+  xxTmp = xx+tendency(params, lon, lat, cMask, yMask, t, xx)*0.5*dti
 
   # Second step
-  xx += tendency(params, lon, lat, t+0.5*dt, xxTmp)*dti
+  xx += tendency(params, lon, lat, cMask, yMask, t+0.5*dt, xxTmp)*dti
 
-def stepNoParams(xx):
-  # Get parameters from globals()
-  params = globals()["params"]
-  lon = globals()["lon"]
-  lat = globals()["lat"]
-  t = globals()["t"]
-
-  # Integration parameters
-  dt = params["dt"]
-  dti = params["dti"]
-
-  # First step
-  xxTmp = xx+tendency(params, lon, lat, t, xx)*0.5*dti
-
-  # Second step
-  xxTmp = xx+tendency(params, lon, lat, t+0.5*dt, xxTmp)*dti
-
-  return xxTmp
-
-def tendency(params, lon, lat, t, xx):
+def tendency(params, lon, lat, cMask, yMask, t, xx):
   # Parameters
   nx = params["nx"]
   ny = params["ny"]
-  ixMin = params["ixMin"]
-  ixMax = params["ixMax"]
-  iyMin = params["iyMin"]
-  iyMax = params["iyMax"]
   F = params["F"]
   omega = params["omega"]
   nu = params["nu"]
@@ -62,40 +39,41 @@ def tendency(params, lon, lat, t, xx):
   # Create tendency
   xxTen = torch.zeros_like(xx)
 
-  for jy in range(ny):
-    for jx in range(nx):
-      if jx >= ixMin and jx <= ixMax and jy >= iyMin and jy <= iyMax:
-        # Inside computation zone
+  # Time-dependent forcing
+  FF = ((1.0+0.4*torch.sin(lon-omega*t)*torch.cos(lat))*F).unsqueeze(0).expand(nz, ny, nx)
 
-        # Retrieve array indices
-        ixp1 = (jx+1)%nx
-        ixm2 = (jx-2)%nx
-        ixm1 = (jx-1)%nx
-        iyp1 = jy+1
-        iym1 = jy-1
+  # Shift state
+  xx_xp1 = torch.roll(xx, shifts=(-1), dims=(2))
+  xx_xm1 = torch.roll(xx, shifts=(1), dims=(2))
+  xx_xm2 = torch.roll(xx, shifts=(2), dims=(2))
+  xx_yp1 = torch.roll(xx, shifts=(-1), dims=(1))
+  xx_ym1 = torch.roll(xx, shifts=(1), dims=(1))
 
-        # Time-dependent forcing
-        FF = (1.0+0.4*torch.sin(lon[jy,jx]-omega*t)*torch.cos(lat[jy,jx]))*F
+  # Usual L95 in x direction
+  xxTen = ((xx_xp1-xx_xm2)*xx_xm1-xx+FF)*cMask
 
-        for jz in range(nz):
-          # Usual L95 in x direction
-          xxTen[jz,jy,jx] = (xx[jz,jy,ixp1]-xx[jz,jy,ixm2])*xx[jz,jy,ixm1]-xx[jz,jy,jx]+FF
+  # Diffusion in x direction
+  xxTen += nu*(xx_xp1+xx_xm1-2.0*xx)*cMask
 
-          # X-direction diffusion
-          xxTen[jz,jy,jx] += nu*(xx[jz,jy,ixp1]-2.0*xx[jz,jy,jx]+xx[jz,jy,ixm1])
-
-          # Y-direction diffusion
-          if jy > iyMin and jy < iyMax:
-            xxTen[jz,jy,jx] += nu*(xx[jz,iyp1,jx]-2.0*xx[jz,jy,jx]+xx[jz,iym1,jx])
+  # Diffusion in y direction
+  xxTen += nu*(xx_yp1+xx_ym1-2.0*xx)*yMask
 
   return xxTen
 
-def stepTL(params, lon, lat, t, xxTraj, dx):
-  # Copy parameters into globals  
-  globals()["params"] = params
-  globals()["lon"] = lon
-  globals()["lat"] = lat
-  globals()["t"] = t
+def stepTL(params, lon, lat, cMask, yMask, t, xxTraj, dx):
+  # Integration parameters
+  dt = params["dt"]
+  dti = params["dti"]
+
+  # Step integration without extra parameters
+  def stepNoParams(xx):
+    # First step
+    xxTmp = xx+tendency(params, lon, lat, cMask, yMask, t, xx)*0.5*dti
+
+    # Second step
+    xxTmp = xx+tendency(params, lon, lat, cMask, yMask, t+0.5*dt, xxTmp)*dti
+
+    return xxTmp
 
   # Compute JVP
   _, dxOut = torch.func.jvp(stepNoParams, (xxTraj,), (dx,))
@@ -103,12 +81,20 @@ def stepTL(params, lon, lat, t, xxTraj, dx):
   # Copy output content into dx
   dx[:,:,:] = dxOut[:,:,:]
 
-def stepAD(params, lon, lat, t, xxTraj, dx):
-  # Copy parameters into globals  
-  globals()["params"] = params
-  globals()["lon"] = lon
-  globals()["lat"] = lat
-  globals()["t"] = t
+def stepAD(params, lon, lat, cMask, yMask, t, xxTraj, dx):
+  # Integration parameters
+  dt = params["dt"]
+  dti = params["dti"]
+
+  # Step integration without extra parameters
+  def stepNoParams(xx):
+    # First step
+    xxTmp = xx+tendency(params, lon, lat, cMask, yMask, t, xx)*0.5*dti
+
+    # Second step
+    xxTmp = xx+tendency(params, lon, lat, cMask, yMask, t+0.5*dt, xxTmp)*dti
+
+    return xxTmp
 
   # Request gradient computation
   xxTraj.requires_grad_()


### PR DESCRIPTION
Following recommendations of @jeromebarre in #15, the pytorch model is now significantly faster. Instead of more than 45 sec. for the `glb_test_linear_model_pytorch` test, only 2.5 sec. are needed now! Still slightly more than the C++ and the numpy implementations, but at least the same order of magnitude.

Fixes #15.