### PR TITLE
Separate alias and transform

### DIFF
--- a/src/vind/Fields.cc
+++ b/src/vind/Fields.cc
@@ -980,13 +980,7 @@ void Fields::read(const eckit::Configuration & config) {
   // Update variables names
   oops::Variables vars_in_file;
   for (const auto & var : vars_) {
-    std::string newVar = var.name();
-    for (const auto & item : geom_.alias()) {
-      if (item.getString("in code") == var.name()) {
-        newVar = item.getString("in file");
-      }
-    }
-    vars_in_file.push_back({newVar, var.metaData(), var.getLevels()});
+    vars_in_file.push_back({geom_.params().fileAlias(var.name()), var.metaData(), var.getLevels()});
   }
 
   // Get input format
@@ -1009,11 +1003,7 @@ void Fields::read(const eckit::Configuration & config) {
 
   // Rename fields
   for (auto & field : fset_) {
-    for (const auto & item : geom_.alias()) {
-      if (item.getString("in file") == field.name()) {
-        field.rename(item.getString("in code"));
-      }
-    }
+    field.rename(geom_.params().codeAlias(field.name()));
   }
 
   // Set fields metadata
@@ -1071,11 +1061,7 @@ void Fields::write(const eckit::Configuration & config) const {
 
   // Rename fields
   for (auto & field : fset_) {
-    for (const auto & item : geom_.alias()) {
-      if (item.getString("in code") == field.name()) {
-        field.rename(item.getString("in file"));
-      }
-    }
+    field.rename(geom_.params().fileAlias(field.name()));
   }
 
   // Get output formats
@@ -1101,11 +1087,7 @@ void Fields::write(const eckit::Configuration & config) const {
 
   // Rename fields
   for (auto & field : fset_) {
-    for (const auto & item : geom_.alias()) {
-      if (item.getString("in file") == field.name()) {
-        field.rename(item.getString("in code"));
-      }
-    }
+    field.rename(geom_.params().codeAlias(field.name()));
   }
 
   // Wait

--- a/src/vind/FieldsIO/FieldsIOAQ.cc
+++ b/src/vind/FieldsIO/FieldsIOAQ.cc
@@ -206,14 +206,17 @@ void FieldsIOAQ::read(const oops::Variables & vars,
       // Get variable view
       auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar].name()]);
 
+      // Get variable in code
+      const std::string var_in_code = geom.params().codeAlias(vars[jvar].name());
+
       // Get transformation parameters (for states only)
       double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        scalingFactor = geom.params().scalingFactor(vars[jvar].name());
-        logTransf = geom.params().logTransf(vars[jvar].name());
-        addConst = geom.params().addConst(vars[jvar].name());
+        scalingFactor = geom.params().scalingFactor(var_in_code);
+        logTransf = geom.params().logTransf(var_in_code);
+        addConst = geom.params().addConst(var_in_code);
       }
 
       if (vars[jvar].getLevels() == 1) {
@@ -611,14 +614,17 @@ void FieldsIOAQ::write(const eckit::Configuration & conf,
       // Get variable view
       const auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar]]);
 
+      // Get variable in code
+      const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
+
       // Get transformation parameters (for states only)
       double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        scalingFactor = geom.params().scalingFactor(vars[jvar]);
-        logTransf = geom.params().logTransf(vars[jvar]);
-        addConst = geom.params().addConst(vars[jvar]);
+        scalingFactor = geom.params().scalingFactor(var_in_code);
+        logTransf = geom.params().logTransf(var_in_code);
+        addConst = geom.params().addConst(var_in_code);
       }
 
       if (fields.fieldSet()[vars[jvar]].shape(1) == 1) {

--- a/src/vind/FieldsIO/FieldsIOAQ.cc
+++ b/src/vind/FieldsIO/FieldsIOAQ.cc
@@ -207,19 +207,13 @@ void FieldsIOAQ::read(const oops::Variables & vars,
       auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar].name()]);
 
       // Get transformation parameters (for states only)
-      double scaleFactor = 1.0;
+      double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        for (const auto & item : geom.alias()) {
-          if (item.getString("in file") == vars[jvar].name()) {
-            scaleFactor = item.getDouble("scaling factor", 1.0);
-            logTransf = item.getBool("log transform", false);
-            if (logTransf) {
-              addConst = item.getDouble("additive constant", 0.0);
-            }
-          }
-        }
+        scalingFactor = geom.params().scalingFactor(vars[jvar].name());
+        logTransf = geom.params().logTransf(vars[jvar].name());
+        addConst = geom.params().addConst(vars[jvar].name());
       }
 
       if (vars[jvar].getLevels() == 1) {
@@ -236,9 +230,9 @@ void FieldsIOAQ::read(const oops::Variables & vars,
           for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
             atlas::gidx_t gidx = grid.index(i, jj);
             if (logTransf) {
-              varView(gidx, 0) = log10((zvar[jj*nx+i] * scaleFactor) + addConst);
+              varView(gidx, 0) = log10((zvar[jj*nx+i] * scalingFactor) + addConst);
             } else {
-              varView(gidx, 0) = zvar[jj*nx+i] * scaleFactor;
+              varView(gidx, 0) = zvar[jj*nx+i] * scalingFactor;
             }
           }
         }
@@ -258,9 +252,9 @@ void FieldsIOAQ::read(const oops::Variables & vars,
             for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
               atlas::gidx_t gidx = grid.index(i, jj);
               if (logTransf) {
-                varView(gidx, k) = log10((zvar[jj*nx+i] * scaleFactor) + addConst);
+                varView(gidx, k) = log10((zvar[jj*nx+i] * scalingFactor) + addConst);
               } else {
-                varView(gidx, k) = zvar[jj*nx+i] * scaleFactor;
+                varView(gidx, k) = zvar[jj*nx+i] * scalingFactor;
               }
             }
           }
@@ -618,19 +612,13 @@ void FieldsIOAQ::write(const eckit::Configuration & conf,
       const auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar]]);
 
       // Get transformation parameters (for states only)
-      double scaleFactor = 1.0;
+      double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        for (const auto & item : geom.alias()) {
-          if (item.getString("in file") == vars[jvar]) {
-            scaleFactor = item.getDouble("scaling factor", 1.0);
-            logTransf = item.getBool("log transform", false);
-            if (logTransf) {
-              addConst = item.getDouble("additive constant", 0.0);
-            }
-          }
-        }
+        scalingFactor = geom.params().scalingFactor(vars[jvar]);
+        logTransf = geom.params().logTransf(vars[jvar]);
+        addConst = geom.params().addConst(vars[jvar]);
       }
 
       if (fields.fieldSet()[vars[jvar]].shape(1) == 1) {
@@ -641,9 +629,9 @@ void FieldsIOAQ::write(const eckit::Configuration & conf,
           for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
             atlas::gidx_t gidx = grid.index(i, jj);
             if (logTransf) {
-              zvar[jj*nx+i] = (pow(10, varView(gidx, 0)) - addConst) / scaleFactor;
+              zvar[jj*nx+i] = (pow(10, varView(gidx, 0)) - addConst) / scalingFactor;
             } else {
-              zvar[jj*nx+i] = varView(gidx, 0) / scaleFactor;
+              zvar[jj*nx+i] = varView(gidx, 0) / scalingFactor;
             }
           }
         }
@@ -662,9 +650,9 @@ void FieldsIOAQ::write(const eckit::Configuration & conf,
             for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
               atlas::gidx_t gidx = grid.index(i, jj);
               if (logTransf) {
-                zvar[jj*nx+i] = (pow(10, varView(gidx, k)) - addConst) / scaleFactor;
+                zvar[jj*nx+i] = (pow(10, varView(gidx, k)) - addConst) / scalingFactor;
               } else {
-                zvar[jj*nx+i] = varView(gidx, k) / scaleFactor;
+                zvar[jj*nx+i] = varView(gidx, k) / scalingFactor;
               }
             }
           }

--- a/src/vind/FieldsIO/FieldsIOBSC.cc
+++ b/src/vind/FieldsIO/FieldsIOBSC.cc
@@ -222,14 +222,17 @@ void FieldsIOBSC::read(const oops::Variables & vars,
       // Get variable view
       auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar].name()]);
 
+      // Get variable in code
+      const std::string var_in_code = geom.params().codeAlias(vars[jvar].name());
+
       // Get transformation parameters (for states only)
       double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        scalingFactor = geom.params().scalingFactor(vars[jvar].name());
-        logTransf = geom.params().logTransf(vars[jvar].name());
-        addConst = geom.params().addConst(vars[jvar].name());
+        scalingFactor = geom.params().scalingFactor(var_in_code);
+        logTransf = geom.params().logTransf(var_in_code);
+        addConst = geom.params().addConst(var_in_code);
       }
 
       if (vars[jvar].getLevels() == 1) {
@@ -253,7 +256,6 @@ void FieldsIOBSC::read(const oops::Variables & vars,
           }
         }
       } else {
-        const std::string var_in_code = geom.params().codeAlias(vars[jvar].name());
         size_t loopMax = geom.vertCoordAvg(var_in_code).size();
         for (size_t k = 0; k < loopMax; ++k) {
           // Read level
@@ -728,8 +730,8 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
     const eckit::LocalConfiguration gridAttr(attributes_, geom.grid().uid());
 
     for (size_t jvar = 0; jvar < vars.size(); ++jvar) {
-      const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
       // Check whether this variable exists
+      const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
       if (nc_inq_varid(ncid, vars[jvar].c_str(), &var_id[jvar]) != NC_NOERR) {
         // Define variable
         if (fields.fieldSet()[vars[jvar]].shape(1) > 1) {
@@ -881,14 +883,17 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
       // Get variable view
       const auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar]]);
 
+      // Get variable in code
+      const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
+
       // Get transformation parameters (for states only)
       double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        scalingFactor = geom.params().scalingFactor(vars[jvar]);
-        logTransf = geom.params().logTransf(vars[jvar]);
-        addConst = geom.params().addConst(vars[jvar]);
+        scalingFactor = geom.params().scalingFactor(var_in_code);
+        logTransf = geom.params().logTransf(var_in_code);
+        addConst = geom.params().addConst(var_in_code);
       }
 
       if (fields.fieldSet()[vars[jvar]].shape(1) == 1) {
@@ -915,7 +920,6 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
         if ((retval = nc_put_vars_float(ncid, var_id[jvar], startp.data(), countp.data(), NULL,
                                         zvar.data()))) ERR(retval, vars[jvar]);
       } else {
-        const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
         auto levels = geom.vertCoordAvg(var_in_code);
         for (size_t k = 0; k < levels.size(); ++k) {
           // Copy data

--- a/src/vind/FieldsIO/FieldsIOBSC.cc
+++ b/src/vind/FieldsIO/FieldsIOBSC.cc
@@ -223,19 +223,13 @@ void FieldsIOBSC::read(const oops::Variables & vars,
       auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar].name()]);
 
       // Get transformation parameters (for states only)
-      double scaleFactor = 1.0;
+      double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        for (const auto & item : geom.alias()) {
-          if (item.getString("in file") == vars[jvar].name()) {
-            scaleFactor = item.getDouble("scaling factor", 1.0);
-            logTransf = item.getBool("log transform", false);
-            if (logTransf) {
-              addConst = item.getDouble("additive constant", 0.0);
-            }
-          }
-        }
+        scalingFactor = geom.params().scalingFactor(vars[jvar].name());
+        logTransf = geom.params().logTransf(vars[jvar].name());
+        addConst = geom.params().addConst(vars[jvar].name());
       }
 
       if (vars[jvar].getLevels() == 1) {
@@ -252,19 +246,14 @@ void FieldsIOBSC::read(const oops::Variables & vars,
           for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
             atlas::gidx_t gidx = grid.index(i, jj);
             if (logTransf) {
-              varView(gidx, 0) = log10((zvar[jj*nx+i] * scaleFactor) + addConst);
+              varView(gidx, 0) = log10((zvar[jj*nx+i] * scalingFactor) + addConst);
             } else {
-              varView(gidx, 0) = zvar[jj*nx+i] * scaleFactor;
+              varView(gidx, 0) = zvar[jj*nx+i] * scalingFactor;
             }
           }
         }
       } else {
-        std::string var_in_code;
-        for (const auto & item : geom.alias()) {
-          if (item.getString("in file") == vars[jvar].name()) {
-            var_in_code = item.getString("in code");
-          }
-        }
+        const std::string var_in_code = geom.params().codeAlias(vars[jvar].name());
         size_t loopMax = geom.vertCoordAvg(var_in_code).size();
         for (size_t k = 0; k < loopMax; ++k) {
           // Read level
@@ -281,9 +270,9 @@ void FieldsIOBSC::read(const oops::Variables & vars,
             for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
               atlas::gidx_t gidx = grid.index(i, jj);
               if (logTransf) {
-                varView(gidx, k) = log10((zvar[jj*nx+i] * scaleFactor) + addConst);
+                varView(gidx, k) = log10((zvar[jj*nx+i] * scalingFactor) + addConst);
               } else {
-                varView(gidx, k) = zvar[jj*nx+i] * scaleFactor;
+                varView(gidx, k) = zvar[jj*nx+i] * scalingFactor;
               }
             }
           }
@@ -416,14 +405,9 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
     localData.add(fields.fieldSet()[vars[jvar]]);
   }
   // Check if there are fields on secondary vertical coordinates.
-  std::string var_in_code;
   std::vector<size_t> lev_vect;
   for (size_t jvar = 0; jvar < vars.size(); ++jvar) {
-    for (const auto & item : geom.alias()) {
-      if (item.getString("in file") == vars[jvar]) {
-        var_in_code = item.getString("in code");
-      }
-    }
+    const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
     if (geom.levels(var_in_code) > 1) {
       lev_vect.push_back(geom.levels(var_in_code));
     }
@@ -744,11 +728,7 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
     const eckit::LocalConfiguration gridAttr(attributes_, geom.grid().uid());
 
     for (size_t jvar = 0; jvar < vars.size(); ++jvar) {
-      for (const auto & item : geom.alias()) {
-        if (item.getString("in file") == vars[jvar]) {
-          var_in_code = item.getString("in code");
-        }
-      }
+      const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
       // Check whether this variable exists
       if (nc_inq_varid(ncid, vars[jvar].c_str(), &var_id[jvar]) != NC_NOERR) {
         // Define variable
@@ -902,19 +882,13 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
       const auto varView = atlas::array::make_view<double, 2>(globalData[vars[jvar]]);
 
       // Get transformation parameters (for states only)
-      double scaleFactor = 1.0;
+      double scalingFactor = 1.0;
       bool logTransf = false;
       double addConst = 0.0;
       if (isState) {
-        for (const auto & item : geom.alias()) {
-          if (item.getString("in file") == vars[jvar]) {
-            scaleFactor = item.getDouble("scaling factor", 1.0);
-            logTransf = item.getBool("log transform", false);
-            if (logTransf) {
-              addConst = item.getDouble("additive constant", 0.0);
-            }
-          }
-        }
+        scalingFactor = geom.params().scalingFactor(vars[jvar]);
+        logTransf = geom.params().logTransf(vars[jvar]);
+        addConst = geom.params().addConst(vars[jvar]);
       }
 
       if (fields.fieldSet()[vars[jvar]].shape(1) == 1) {
@@ -925,9 +899,9 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
           for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
             atlas::gidx_t gidx = grid.index(i, jj);
             if (logTransf) {
-              zvar[jj*nx_out+i] = (pow(10, varView(gidx, 0)) - addConst) / scaleFactor;
+              zvar[jj*nx_out+i] = (pow(10, varView(gidx, 0)) - addConst) / scalingFactor;
             } else {
-              zvar[jj*nx_out+i] = varView(gidx, 0) / scaleFactor;
+              zvar[jj*nx_out+i] = varView(gidx, 0) / scalingFactor;
             }
           }
           if (isGlobal) {
@@ -941,11 +915,7 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
         if ((retval = nc_put_vars_float(ncid, var_id[jvar], startp.data(), countp.data(), NULL,
                                         zvar.data()))) ERR(retval, vars[jvar]);
       } else {
-        for (const auto & item : geom.alias()) {
-          if (item.getString("in file") == vars[jvar]) {
-            var_in_code = item.getString("in code");
-          }
-        }
+        const std::string var_in_code = geom.params().codeAlias(vars[jvar]);
         auto levels = geom.vertCoordAvg(var_in_code);
         for (size_t k = 0; k < levels.size(); ++k) {
           // Copy data
@@ -955,9 +925,9 @@ void FieldsIOBSC::write(const eckit::Configuration & conf,
             for (atlas::idx_t i = 0; i < grid.nx(jj); ++i) {
               atlas::gidx_t gidx = grid.index(i, jj);
               if (logTransf) {
-                zvar[jj*nx_out+i] = (pow(10, varView(gidx, k)) - addConst) / scaleFactor;
+                zvar[jj*nx_out+i] = (pow(10, varView(gidx, k)) - addConst) / scalingFactor;
               } else {
-                zvar[jj*nx_out+i] = varView(gidx, k) / scaleFactor;
+                zvar[jj*nx_out+i] = varView(gidx, k) / scalingFactor;
               }
             }
             if (isGlobal) {

--- a/src/vind/Geometry.cc
+++ b/src/vind/Geometry.cc
@@ -42,15 +42,15 @@ Geometry::Geometry(const eckit::Configuration & config,
   : comm_(comm), groups_() {
   oops::Log::trace() << classname() << "::Geometry starting" << std::endl;
 
-  GeometryParameters params;
-  params.deserialize(config);
+  // Deserialize and save parameters
+  params_.deserialize(config);
 
   // Setup atlas geometric data structures
   atlas::FieldSet fieldsetOwnedMask;
   util::setupFunctionSpace(comm_, config, grid_, partitioner_, mesh_, functionSpace_,
     fieldsetOwnedMask);
-  halo_ = params.halo.value();
-  gridType_ = params.grid.value().getString("type", "no_type");
+  halo_ = params_.halo.value();
+  gridType_ = params_.grid.value().getString("type", "no_type");
 
   // Deal with poles for structured grids
   if (((gridType_ == "structured") || (gridType_ == "regular_lonlat")) && grid_.domain().global()) {
@@ -99,23 +99,23 @@ Geometry::Geometry(const eckit::Configuration & config,
   fields_.add(fieldsetOwnedMask["owned"]);
 
   // Levels direction
-  levelsAreTopDown_ = params.levelsAreTopDown.value();
+  levelsAreTopDown_ = params_.levelsAreTopDown.value();
 
   // Levels counter origin
-  levelsCountFrom_ = params.levelsCountFrom.value();
+  levelsCountFrom_ = params_.levelsCountFrom.value();
 
   // Model data
-  modelData_ = params.modelData.value();
+  modelData_ = params_.modelData.value();
 
   // Variable name alias
-  setupAlias(params);
+  setupAlias();
 
   // IO parameters
-  io_ = params.io.value();
+  io_ = params_.io.value();
 
   // Interpolation
-  const auto &interpParams = params.interpolation.value();
-  if (interpParams != boost::none) {
+  const auto &interpParams = params_.interpolation.value();
+  if (interpParams) {
     interpolation_ = interpParams->toConfiguration();
   } else {
     interpolation_ = eckit::LocalConfiguration();
@@ -137,7 +137,7 @@ Geometry::Geometry(const eckit::Configuration & config,
 
   // Groups
   size_t groupIndex = 0;
-  for (const auto & groupParams : params.groups.value()) {
+  for (const auto & groupParams : params_.groups.value()) {
     // Define group
     groupData group;
 
@@ -178,13 +178,10 @@ Geometry::Geometry(const eckit::Configuration & config,
   }
 
   // Check lon/lat from files
-  const auto &checkLonLatConf = params.checkLonLat.value();
-  if (checkLonLatConf != boost::none) {
-    checkLonLat(*checkLonLatConf);
-  }
+  checkLonLat();
 
   // Setup iterator
-  setupIterator(config);
+  setupIterator();
 
   // Print summary
   print(oops::Log::info());
@@ -332,36 +329,33 @@ void Geometry::print(std::ostream & os) const {
 
 // -----------------------------------------------------------------------------
 
-void Geometry::setupAlias(const GeometryParameters & params) {
+void Geometry::setupAlias() {
   oops::Log::trace() << classname() << "::setupAlias starting" << std::endl;
 
-  for (const auto & item : params.alias.value()) {
-    eckit::LocalConfiguration confItem;
-    item.serialize(confItem);
-    alias_.push_back(confItem);
+  // Add pairs into vector
+  for (const auto & item : params_.alias.value()) {
+    alias_.push_back(std::make_pair(item.inCode, item.inFile));
   }
 
   // Check alias consistency
   std::vector<std::string> vars;
-  for (const auto & groupParams : params.groups.value()) {
+  for (const auto & groupParams : params_.groups.value()) {
     const std::vector<std::string> grpVars = groupParams.variables.value();
     vars.insert(vars.end(), grpVars.begin(), grpVars.end());
   }
   for (const auto & item : alias_) {
-    const std::string codeVar = item.getString("in code");
-    if (std::find(vars.begin(), vars.end(), codeVar) == vars.end()) {
+    if (std::find(vars.begin(), vars.end(), item.first) == vars.end()) {
       // Code variable not available in the list of variables anymore
       throw eckit::UserError("Alias error: code variable not available anymore", Here());
     } else {
       // Remove code variable from the list of available variables
-      vars.erase(std::remove(vars.begin(), vars.end(), codeVar), vars.end());
+      vars.erase(std::remove(vars.begin(), vars.end(), item.first), vars.end());
     }
   }
   for (const auto & item : alias_) {
-    const std::string fileVar = item.getString("in file");
-    if (std::find(vars.begin(), vars.end(), fileVar) == vars.end()) {
+    if (std::find(vars.begin(), vars.end(), item.second) == vars.end()) {
       // Add file variable to the list of variables
-      vars.push_back(fileVar);
+      vars.push_back(item.second);
     } else {
       // File variable is already present in the list of variables
       throw eckit::UserError("Alias error: duplicated file variable", Here());
@@ -381,7 +375,7 @@ void Geometry::setupVertCoord(groupData & group) {
 
   // Get vertical coordinate name
   std::string vertCoordName = "vert_coord_" + std::to_string(group.index_);
-  if (vertCoordConf != boost::none) {
+  if (vertCoordConf) {
     if (vertCoordConf->has("name")) {
       vertCoordName = vertCoordConf->getString("name");
     }
@@ -397,7 +391,7 @@ void Geometry::setupVertCoord(groupData & group) {
   // Get view
   auto vertCoordView = atlas::array::make_view<double, 2>(group.vertCoord_);
 
-  if (vertCoordConf != boost::none) {
+  if (vertCoordConf) {
     // Vertical coordinate from a configuration
     if (vertCoordConf->has("profile")) {
       // From a vector of doubles (one for each level)
@@ -476,7 +470,7 @@ void Geometry::setupVertCoord(groupData & group) {
 
   // Add orography (mountain) on bottom level
   const auto &orographyParams = group.params_.orography.value();
-  if (orographyParams != boost::none) {
+  if (orographyParams) {
     // Get top latitude value
     const atlas::PointLonLat topPoint({orographyParams->topLon.value(),
       orographyParams->topLat.value()});
@@ -674,13 +668,16 @@ void Geometry::setupMask(groupData & group) {
 
 // -----------------------------------------------------------------------------
 
-void Geometry::checkLonLat(const eckit::Configuration & checkLonLatConf) {
+void Geometry::checkLonLat() {
   oops::Log::trace() << classname() << "::checkLonLat starting" << std::endl;
 
   // Return if configuration is empty
-  if (checkLonLatConf.empty()) {
+  if (!params_.checkLonLat.value()) {
     return;
   }
+
+  // Get configuration
+  const auto & checkLonLatConf = *params_.checkLonLat.value();
 
   // Get variable to read
   const std::string lonName = checkLonLatConf.getString("longitude", "longitude");
@@ -730,14 +727,14 @@ void Geometry::checkLonLat(const eckit::Configuration & checkLonLatConf) {
 
 // -----------------------------------------------------------------------------
 
-void Geometry::setupIterator(const eckit::Configuration & config) {
+void Geometry::setupIterator() {
   oops::Log::trace() << classname() << "::setupIterator starting" << std::endl;
 
   // Common vertical coordinate
-  commonVerticalCoordinate_ = config.getString("common vertical coordinate", "vert_coord_0");
+  commonVerticalCoordinate_ = params_.commonVertCoord.value();
 
   // Iterator dimension
-  iteratorDimension_ = config.getInt("iterator dimension", 2);
+  iteratorDimension_ = params_.iteratorDim.value();
   ASSERT((iteratorDimension_ == 2) || (iteratorDimension_ == 3));
 
   // First group vertical coordinate field

--- a/src/vind/Geometry.h
+++ b/src/vind/Geometry.h
@@ -12,6 +12,7 @@
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "atlas/field.h"
@@ -88,10 +89,10 @@ class Geometry : public util::Printable,
   size_t groups() const
     {return groups_.size();}
   size_t groupIndex(const std::string &) const;
+  const GeometryParameters & params() const
+    {return params_;}
   const eckit::LocalConfiguration & modelData() const
     {return modelData_;}
-  const std::vector<eckit::LocalConfiguration> & alias() const
-    {return alias_;}
   const eckit::LocalConfiguration & io() const
     {return io_;}
   const eckit::LocalConfiguration & interpolation() const
@@ -121,6 +122,10 @@ class Geometry : public util::Printable,
     {return nnodes_;}
   const size_t & nlevs() const
     {return nlevs_;}
+
+  // Variables alias
+  std::string fileAlias(const std::string &) const;
+  std::string codeAlias(const std::string &) const;
 
  private:
   // Communicator
@@ -157,6 +162,9 @@ class Geometry : public util::Printable,
     double gmaskSize_;
   };
 
+  // Parameters
+  GeometryParameters params_;
+
   // Geometry fields
   atlas::FieldSet fields_;
 
@@ -172,8 +180,11 @@ class Geometry : public util::Printable,
   // Model data configuration
   eckit::LocalConfiguration modelData_;
 
-  // Variables name alias
-  std::vector<eckit::LocalConfiguration> alias_;
+  // Variable alias
+  std::vector<std::pair<std::string, std::string>> alias_;
+
+  // Variable transform
+  std::vector<eckit::LocalConfiguration> transform_;
 
   // IO configuration
   eckit::LocalConfiguration io_;
@@ -204,7 +215,7 @@ class Geometry : public util::Printable,
   void print(std::ostream &) const;
 
   // Setup alias
-  void setupAlias(const GeometryParameters &);
+  void setupAlias();
 
   // Setup group vertical coordinate
   void setupVertCoord(groupData &);
@@ -213,10 +224,10 @@ class Geometry : public util::Printable,
   void setupMask(groupData &);
 
   // Check longitudes/latitudes from file
-  void checkLonLat(const eckit::Configuration &);
+  void checkLonLat();
 
   // Setup iterator
-  void setupIterator(const eckit::Configuration &);
+  void setupIterator();
 };
 
 // -----------------------------------------------------------------------------

--- a/src/vind/GeometryParameters.h
+++ b/src/vind/GeometryParameters.h
@@ -83,7 +83,17 @@ class AliasParameters : public oops::Parameters {
   oops::RequiredParameter<std::string> inCode{"in code", this};
   // In model file
   oops::RequiredParameter<std::string> inFile{"in file", this};
-  // Optional parameters for States transformations
+};
+
+// -----------------------------------------------------------------------------
+/// Transform elemental paramaters
+
+class TransformParameters : public oops::Parameters {
+  OOPS_CONCRETE_PARAMETERS(TransformParameters, oops::Parameters)
+
+ public:
+  // Variable name
+  oops::RequiredParameter<std::string> variable{"variable", this};
   // Scaling factor (e.g. for units conversion)
   oops::OptionalParameter<double> scalingFactor{"scaling factor", this};
   // Toggle log10 transformation
@@ -138,8 +148,11 @@ class GeometryParameters : public oops::Parameters {
   oops::Parameter<eckit::LocalConfiguration> modelData{"model data", eckit::LocalConfiguration(),
     this};
 
-  // Variables name alias for model files
+  // Variable alias (different name in file and in code)
   oops::Parameter<std::vector<AliasParameters>> alias{"alias", {}, this};
+
+  // Variable transform
+  oops::Parameter<std::vector<TransformParameters>> transform{"transform", {}, this};
 
   // Check longitudes/latitudes from file
   oops::OptionalParameter<eckit::LocalConfiguration> checkLonLat{"check lon/lat from file", this};
@@ -149,6 +162,75 @@ class GeometryParameters : public oops::Parameters {
 
   // Interpolation parameters
   oops::OptionalParameter<InterpolationParameters> interpolation{"interpolation", this};
+
+  // Geometry iterator common vertical coordinate
+  oops::Parameter<std::string> commonVertCoord{"common vertical coordinate", "vert_coord_0", this};
+
+  // Geometry iterator dimension
+  oops::Parameter<size_t> iteratorDim{"iterator dimension", 2, this};
+
+  // Helpers
+
+  // Return variable name in model file
+  std::string fileAlias(const std::string & inCode) const {
+    for (const auto & item : alias.value()) {
+      if (item.inCode.value() == inCode) {
+        return item.inFile.value();
+      }
+    }
+    // Default value: input
+    return inCode;
+  }
+
+  // Return variable name in code
+  std::string codeAlias(const std::string & inFile) const {
+    for (const auto & item : alias.value()) {
+      if (item.inFile.value() == inFile) {
+        return item.inCode.value();
+      }
+    }
+    // Default value: input
+    return inFile;
+  }
+
+  // Return scaling factor
+  double scalingFactor(const std::string & varName) const {
+    for (const auto & item : transform.value()) {
+      if (item.variable.value() == varName) {
+        if (item.scalingFactor.value()) {
+          return *item.scalingFactor.value();
+        }
+      }
+    }
+    // Default value: 1.0
+    return 1.0;
+  }
+
+  // Return toggle for log10 transformation
+  bool logTransf(const std::string & varName) const {
+    for (const auto & item : transform.value()) {
+      if (item.variable.value() == varName) {
+        if (item.logTransf.value()) {
+          return *item.logTransf.value();
+        }
+      }
+    }
+    // Default value: false
+    return false;
+  }
+
+  // Return scaling factor
+  double addConst(const std::string & varName) const {
+    for (const auto & item : transform.value()) {
+      if (item.variable.value() == varName) {
+        if (item.addConst.value()) {
+          return *item.addConst.value();
+        }
+      }
+    }
+    // Default value: 0.0
+    return 0.0;
+  }
 };
 
 // -----------------------------------------------------------------------------

--- a/src/vind/LinearVariableChange.cc
+++ b/src/vind/LinearVariableChange.cc
@@ -32,10 +32,10 @@ LinearVariableChange::LinearVariableChange(const Geometry & geom,
   LinearVariableChangeParameters params;
   params.deserialize(config);
 
-  if (params.atlasFile.value() != boost::none) {
+  if (params.atlasFile.value()) {
     // Check that input and output variables are present
-    ASSERT(params.inputVariables.value() != boost::none);
-    ASSERT(params.outputVariables.value() != boost::none);
+    ASSERT(params.inputVariables.value());
+    ASSERT(params.outputVariables.value());
 
     // Define output to input variables map
     ASSERT(params.inputVariables.value()->size() == params.outputVariables.value()->size());

--- a/src/vind/VariableChange.cc
+++ b/src/vind/VariableChange.cc
@@ -35,7 +35,7 @@ VariableChange::VariableChange(const eckit::Configuration & config,
   params.deserialize(config);
 
   const boost::optional<vader::VaderParameters> &vaderParam = params.vaderParam.value();
-  if (vaderParam != boost::none) {
+  if (vaderParam) {
     // Pass model data parameters to vader configuration
     ModelData modelData(geom);
 

--- a/test/aq/testinput/3densvar_lt.yaml
+++ b/test/aq/testinput/3densvar_lt.yaml
@@ -57,22 +57,29 @@ cost function:
     alias:
     - in code: ozone
       in file: O3
-      <<: *logtransform
-      additive constant: *o3addconst
     - in code: carbon_monoxide
       in file: CO
-      <<: *logtransform
     - in code: nitrogen_dioxide
       in file: NO2
-      <<: *logtransform
     - in code: sulfur_dioxide
       in file: SO2
-      <<: *logtransform
     - in code: pm10
       in file: dry_pm10_mass
-      <<: *logtransform
     - in code: pm2p5
       in file: dry_pm2p5_mass
+    transform:
+    - variable: O3
+      <<: *logtransform
+      additive constant: *o3addconst
+    - variable: CO
+      <<: *logtransform
+    - variable: NO2
+      <<: *logtransform
+    - variable: SO2
+      <<: *logtransform
+    - variable: dry_pm10_mass
+      <<: *logtransform
+    - variable: dry_pm2p5_mass
       <<: *logtransform
     io:
       initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/3densvar_lt.yaml
+++ b/test/aq/testinput/3densvar_lt.yaml
@@ -68,18 +68,18 @@ cost function:
     - in code: pm2p5
       in file: dry_pm2p5_mass
     transform:
-    - variable: O3
+    - variable: ozone
       <<: *logtransform
       additive constant: *o3addconst
-    - variable: CO
+    - variable: carbon_monoxide
       <<: *logtransform
-    - variable: NO2
+    - variable: nitrogen_dioxide
       <<: *logtransform
-    - variable: SO2
+    - variable: sulfur_dioxide
       <<: *logtransform
-    - variable: dry_pm10_mass
+    - variable: pm10
       <<: *logtransform
-    - variable: dry_pm2p5_mass
+    - variable: pm2p5
       <<: *logtransform
     io:
       initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/4densvar_lt.yaml
+++ b/test/aq/testinput/4densvar_lt.yaml
@@ -81,22 +81,29 @@ cost function:
     alias:
     - in code: ozone
       in file: O3
-      <<: *logtransform
-      additive constant: *o3addconst
     - in code: carbon_monoxide
       in file: CO
-      <<: *logtransform
     - in code: nitrogen_dioxide
       in file: NO2
-      <<: *logtransform
     - in code: sulfur_dioxide
       in file: SO2
-      <<: *logtransform
     - in code: pm10
       in file: dry_pm10_mass
-      <<: *logtransform
     - in code: pm2p5
       in file: dry_pm2p5_mass
+    transform:
+    - variable: ozone
+      <<: *logtransform
+      additive constant: *o3addconst
+    - variable: carbon_monoxide
+      <<: *logtransform
+    - variable: nitrogen_dioxide
+      <<: *logtransform
+    - variable: sulfur_dioxide
+      <<: *logtransform
+    - variable: pm10
+      <<: *logtransform
+    - variable: pm2p5
       <<: *logtransform
     io:
       initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/convertstate_logtransf.yaml
+++ b/test/aq/testinput/convertstate_logtransf.yaml
@@ -46,18 +46,18 @@ input geometry: &geom
   - in code: pm2p5
     in file: dry_pm2p5_mass
   transform:
-  - variable: O3
+  - variable: ozone
     <<: *logtransform
     additive constant: *o3addconst
-  - variable: CO
+  - variable: carbon_monoxide
     <<: *logtransform
-  - variable: NO2
+  - variable: nitrogen_dioxide
     <<: *logtransform
-  - variable: SO2
+  - variable: sulfur_dioxide
     <<: *logtransform
-  - variable: dry_pm10_mass
+  - variable: pm10
     <<: *logtransform
-  - variable: dry_pm2p5_mass
+  - variable: pm2p5
     <<: *logtransform
   io:
     initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/convertstate_logtransf.yaml
+++ b/test/aq/testinput/convertstate_logtransf.yaml
@@ -33,25 +33,31 @@ input geometry: &geom
     vertical coordinate:
       profile: [19, 20, 21, 22, 23]
   alias:
-  alias:
   - in code: ozone
     in file: O3
-    <<: *logtransform
-    additive constant: *o3addconst
   - in code: carbon_monoxide
     in file: CO
-    <<: *logtransform
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *logtransform
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *logtransform
   - in code: pm10
     in file: dry_pm10_mass
-    <<: *logtransform
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: O3
+    <<: *logtransform
+    additive constant: *o3addconst
+  - variable: CO
+    <<: *logtransform
+  - variable: NO2
+    <<: *logtransform
+  - variable: SO2
+    <<: *logtransform
+  - variable: dry_pm10_mass
+    <<: *logtransform
+  - variable: dry_pm2p5_mass
     <<: *logtransform
   io:
     initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/dirac_no_loc_3d_lt.yaml
+++ b/test/aq/testinput/dirac_no_loc_3d_lt.yaml
@@ -51,18 +51,18 @@ geometry:
   - in code: pm2p5
     in file: dry_pm2p5_mass
   transform:
-  - variable: O3
+  - variable: ozone
     <<: *logtransform
     additive constant: *o3addconst
-  - variable: CO
+  - variable: carbon_monoxide
     <<: *logtransform
-  - variable: NO2
+  - variable: nitrogen_dioxide
     <<: *logtransform
-  - variable: SO2
+  - variable: sulfur_dioxide
     <<: *logtransform
-  - variable: dry_pm10_mass
+  - variable: pm10
     <<: *logtransform
-  - variable: dry_pm2p5_mass
+  - variable: pm2p5
     <<: *logtransform
   io:
     initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/dirac_no_loc_3d_lt.yaml
+++ b/test/aq/testinput/dirac_no_loc_3d_lt.yaml
@@ -40,22 +40,29 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *logtransform
-    additive constant: *o3addconst
   - in code: carbon_monoxide
     in file: CO
-    <<: *logtransform
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *logtransform
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *logtransform
   - in code: pm10
     in file: dry_pm10_mass
-    <<: *logtransform
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: O3
+    <<: *logtransform
+    additive constant: *o3addconst
+  - variable: CO
+    <<: *logtransform
+  - variable: NO2
+    <<: *logtransform
+  - variable: SO2
+    <<: *logtransform
+  - variable: dry_pm10_mass
+    <<: *logtransform
+  - variable: dry_pm2p5_mass
     <<: *logtransform
   io:
     initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/hofx3d_logarithm.yaml
+++ b/test/aq/testinput/hofx3d_logarithm.yaml
@@ -44,22 +44,29 @@ geometry: &geom
   alias:
   - in code: ozone
     in file: O3
-    <<: *logtransform
-    additive constant: *o3addconst
   - in code: carbon_monoxide
     in file: CO
-    <<: *logtransform
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *logtransform
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *logtransform
   - in code: pm10
     in file: dry_pm10_mass
-    <<: *logtransform
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: O3
+    <<: *logtransform
+    additive constant: *o3addconst
+  - variable: CO
+    <<: *logtransform
+  - variable: NO2
+    <<: *logtransform
+  - variable: SO2
+    <<: *logtransform
+  - variable: dry_pm10_mass
+    <<: *logtransform
+  - variable: dry_pm2p5_mass
     <<: *logtransform
   io:
     initial date: 2022-06-30T12:00:00Z

--- a/test/aq/testinput/hofx3d_logarithm.yaml
+++ b/test/aq/testinput/hofx3d_logarithm.yaml
@@ -55,18 +55,18 @@ geometry: &geom
   - in code: pm2p5
     in file: dry_pm2p5_mass
   transform:
-  - variable: O3
+  - variable: ozone
     <<: *logtransform
     additive constant: *o3addconst
-  - variable: CO
+  - variable: carbon_monoxide
     <<: *logtransform
-  - variable: NO2
+  - variable: nitrogen_dioxide
     <<: *logtransform
-  - variable: SO2
+  - variable: sulfur_dioxide
     <<: *logtransform
-  - variable: dry_pm10_mass
+  - variable: pm10
     <<: *logtransform
-  - variable: dry_pm2p5_mass
+  - variable: pm2p5
     <<: *logtransform
   io:
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/3densvar.yaml
+++ b/test/monarch/testinput/3densvar.yaml
@@ -61,20 +61,25 @@ cost function:
     alias:
     - in code: ozone
       in file: O3
-      <<: *scalegas
     - in code: carbon_monoxide
       in file: CO
-      <<: *scalegas
     - in code: nitrogen_dioxide
       in file: NO2
-      <<: *scalegas
     - in code: sulfur_dioxide
       in file: SO2
-      <<: *scalegas
     - in code: pm10
       in file: dry_pm10_mass
     - in code: pm2p5
       in file: dry_pm2p5_mass
+    transform:
+    - variable: ozone
+      <<: *scalegas
+    - variable: carbon_monoxide
+      <<: *scalegas
+    - variable: nitrogen_dioxide
+      <<: *scalegas
+    - variable: sulfur_dioxide
+      <<: *scalegas
     io:
       total number of levels: 24
       initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/3densvar_lt.yaml
+++ b/test/monarch/testinput/3densvar_lt.yaml
@@ -79,22 +79,22 @@ cost function:
     - in code: pm2p5
       in file: dry_pm2p5_mass
     transform:
-    - variable: O3
+    - variable: ozone
       <<: *scalegas
       <<: *logtransform
       additive constant: *o3addconst
-    - variable: CO
+    - variable: carbon_monoxide
       <<: *scalegas
       <<: *logtransform
-    - variable: NO2
+    - variable: nitrogen_dioxide
       <<: *scalegas
       <<: *logtransform
-    - variable: SO2
+    - variable: sulfur_dioxide
       <<: *scalegas
       <<: *logtransform
-    - variable: dry_pm10_mass
+    - variable: pm10
       <<: *logtransform
-    - variable: dry_pm2p5_mass
+    - variable: pm2p5
       <<: *logtransform
     io:
       total number of levels: 24

--- a/test/monarch/testinput/3densvar_lt.yaml
+++ b/test/monarch/testinput/3densvar_lt.yaml
@@ -68,26 +68,33 @@ cost function:
     alias:
     - in code: ozone
       in file: O3
+    - in code: carbon_monoxide
+      in file: CO
+    - in code: nitrogen_dioxide
+      in file: NO2
+    - in code: sulfur_dioxide
+      in file: SO2
+    - in code: pm10
+      in file: dry_pm10_mass
+    - in code: pm2p5
+      in file: dry_pm2p5_mass
+    transform:
+    - variable: O3
       <<: *scalegas
       <<: *logtransform
       additive constant: *o3addconst
-    - in code: carbon_monoxide
-      in file: CO
+    - variable: CO
       <<: *scalegas
       <<: *logtransform
-    - in code: nitrogen_dioxide
-      in file: NO2
+    - variable: NO2
       <<: *scalegas
       <<: *logtransform
-    - in code: sulfur_dioxide
-      in file: SO2
+    - variable: SO2
       <<: *scalegas
       <<: *logtransform
-    - in code: pm10
-      in file: dry_pm10_mass
+    - variable: dry_pm10_mass
       <<: *logtransform
-    - in code: pm2p5
-      in file: dry_pm2p5_mass
+    - variable: dry_pm2p5_mass
       <<: *logtransform
     io:
       total number of levels: 24

--- a/test/monarch/testinput/4densvar.yaml
+++ b/test/monarch/testinput/4densvar.yaml
@@ -86,20 +86,25 @@ cost function:
     alias:
     - in code: ozone
       in file: O3
-      <<: *scalegas
     - in code: carbon_monoxide
       in file: CO
-      <<: *scalegas
     - in code: nitrogen_dioxide
       in file: NO2
-      <<: *scalegas
     - in code: sulfur_dioxide
       in file: SO2
-      <<: *scalegas
     - in code: pm10
       in file: dry_pm10_mass
     - in code: pm2p5
       in file: dry_pm2p5_mass
+    transform:
+    - variable: ozone
+      <<: *scalegas
+    - variable: carbon_monoxide
+      <<: *scalegas
+    - variable: nitrogen_dioxide
+      <<: *scalegas
+    - variable: sulfur_dioxide
+      <<: *scalegas
     io:
       total number of levels: 24
       initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/4densvar_lt.yaml
+++ b/test/monarch/testinput/4densvar_lt.yaml
@@ -88,26 +88,33 @@ cost function:
     alias:
     - in code: ozone
       in file: O3
+    - in code: carbon_monoxide
+      in file: CO
+    - in code: nitrogen_dioxide
+      in file: NO2
+    - in code: sulfur_dioxide
+      in file: SO2
+    - in code: pm10
+      in file: dry_pm10_mass
+    - in code: pm2p5
+      in file: dry_pm2p5_mass
+    transform:
+    - variable: ozone
       <<: *scalegas
       <<: *logtransform
       additive constant: *o3addconst
-    - in code: carbon_monoxide
-      in file: CO
+    - variable: carbon_monoxide
       <<: *scalegas
       <<: *logtransform
-    - in code: nitrogen_dioxide
-      in file: NO2
+    - variable: nitrogen_dioxide
       <<: *scalegas
       <<: *logtransform
-    - in code: sulfur_dioxide
-      in file: SO2
+    - variable: sulfur_dioxide
       <<: *scalegas
       <<: *logtransform
-    - in code: pm10
-      in file: dry_pm10_mass
+    - variable: pm10
       <<: *logtransform
-    - in code: pm2p5
-      in file: dry_pm2p5_mass
+    - variable: pm2p5
       <<: *logtransform
     io:
       total number of levels: 24

--- a/test/monarch/testinput/convertstate_levsel_logtransf.yaml
+++ b/test/monarch/testinput/convertstate_levsel_logtransf.yaml
@@ -59,16 +59,10 @@ input geometry: &geom
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
-    <<: *logtransform
-    additive constant: *o3addconst
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
-    <<: *logtransform
   - in code: pm10
     in file: dry_pm10_mass
-    <<: *logtransform
   - in code: lev_height
     in file: mid_layer_height_agl
   - in code: air_pressure
@@ -79,6 +73,16 @@ input geometry: &geom
     in file: PSFC
   - in code: surface_geopotential
     in file: FIS
+  transform:
+  - variable: O3
+    <<: *scalegas
+    <<: *logtransform
+    additive constant: *o3addconst
+  - variable: CO
+    <<: *scalegas
+    <<: *logtransform
+  - variable: dry_pm10_mass
+    <<: *logtransform
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/convertstate_levsel_logtransf.yaml
+++ b/test/monarch/testinput/convertstate_levsel_logtransf.yaml
@@ -74,14 +74,14 @@ input geometry: &geom
   - in code: surface_geopotential
     in file: FIS
   transform:
-  - variable: O3
+  - variable: ozone
     <<: *scalegas
     <<: *logtransform
     additive constant: *o3addconst
-  - variable: CO
+  - variable: carbon_monoxide
     <<: *scalegas
     <<: *logtransform
-  - variable: dry_pm10_mass
+  - variable: pm10
     <<: *logtransform
   io:
     total number of levels: 24

--- a/test/monarch/testinput/convertstate_levsel_scaling.yaml
+++ b/test/monarch/testinput/convertstate_levsel_scaling.yaml
@@ -52,10 +52,8 @@ input geometry: &geom
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: lev_height
@@ -68,6 +66,11 @@ input geometry: &geom
     in file: PSFC
   - in code: surface_geopotential
     in file: FIS
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/dirac_3d.yaml
+++ b/test/monarch/testinput/dirac_3d.yaml
@@ -46,20 +46,25 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/dirac_3d_FL.yaml
+++ b/test/monarch/testinput/dirac_3d_FL.yaml
@@ -46,20 +46,25 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/dirac_4d.yaml
+++ b/test/monarch/testinput/dirac_4d.yaml
@@ -63,20 +63,25 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/dirac_4d_FL.yaml
+++ b/test/monarch/testinput/dirac_4d_FL.yaml
@@ -63,20 +63,25 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/dirac_no_loc_3d.yaml
+++ b/test/monarch/testinput/dirac_no_loc_3d.yaml
@@ -46,20 +46,25 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/dirac_no_loc_3d_lt.yaml
+++ b/test/monarch/testinput/dirac_no_loc_3d_lt.yaml
@@ -64,22 +64,22 @@ geometry:
   - in code: pm2p5
     in file: dry_pm2p5_mass
   transform:
-  - variable: O3
+  - variable: ozone
     <<: *scalegas
     <<: *logtransform
     additive constant: *o3addconst
-  - variable: CO
+  - variable: carbon_monoxide
     <<: *scalegas
     <<: *logtransform
-  - variable: NO2
+  - variable: nitrogen_dioxide
     <<: *scalegas
     <<: *logtransform
-  - variable: SO2
+  - variable: sulfur_dioxide
     <<: *scalegas
     <<: *logtransform
-  - variable: dry_pm10_mass
+  - variable: pm10
     <<: *logtransform
-  - variable: dry_pm2p5_mass
+  - variable: pm2p5
     <<: *logtransform
   io:
     total number of levels: 24

--- a/test/monarch/testinput/dirac_no_loc_3d_lt.yaml
+++ b/test/monarch/testinput/dirac_no_loc_3d_lt.yaml
@@ -53,26 +53,33 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
+  - in code: carbon_monoxide
+    in file: CO
+  - in code: nitrogen_dioxide
+    in file: NO2
+  - in code: sulfur_dioxide
+    in file: SO2
+  - in code: pm10
+    in file: dry_pm10_mass
+  - in code: pm2p5
+    in file: dry_pm2p5_mass
+  transform:
+  - variable: O3
     <<: *scalegas
     <<: *logtransform
     additive constant: *o3addconst
-  - in code: carbon_monoxide
-    in file: CO
+  - variable: CO
     <<: *scalegas
     <<: *logtransform
-  - in code: nitrogen_dioxide
-    in file: NO2
+  - variable: NO2
     <<: *scalegas
     <<: *logtransform
-  - in code: sulfur_dioxide
-    in file: SO2
+  - variable: SO2
     <<: *scalegas
     <<: *logtransform
-  - in code: pm10
-    in file: dry_pm10_mass
+  - variable: dry_pm10_mass
     <<: *logtransform
-  - in code: pm2p5
-    in file: dry_pm2p5_mass
+  - variable: dry_pm2p5_mass
     <<: *logtransform
   io:
     total number of levels: 24

--- a/test/monarch/testinput/dirac_no_loc_4d.yaml
+++ b/test/monarch/testinput/dirac_no_loc_4d.yaml
@@ -63,20 +63,25 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/hofx3d_constant.yaml
+++ b/test/monarch/testinput/hofx3d_constant.yaml
@@ -49,20 +49,25 @@ geometry: &geom
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monarch/testinput/hofx3d_logarithm.yaml
+++ b/test/monarch/testinput/hofx3d_logarithm.yaml
@@ -67,22 +67,22 @@ geometry: &geom
   - in code: pm2p5
     in file: dry_pm2p5_mass
   transform:
-  - variable: O3
+  - variable: ozone
     <<: *scalegas
     <<: *logtransform
     additive constant: *o3addconst
-  - variable: CO
+  - variable: carbon_monoxide
     <<: *scalegas
     <<: *logtransform
-  - variable: NO2
+  - variable: nitrogen_dioxide
     <<: *scalegas
     <<: *logtransform
-  - variable: SO2
+  - variable: sulfur_dioxide
     <<: *scalegas
     <<: *logtransform
-  - variable: dry_pm10_mass
+  - variable: pm10
     <<: *logtransform
-  - variable: dry_pm2p5_mass
+  - variable: pm2p5
     <<: *logtransform
   io:
     total number of levels: 24

--- a/test/monarch/testinput/hofx3d_logarithm.yaml
+++ b/test/monarch/testinput/hofx3d_logarithm.yaml
@@ -56,26 +56,33 @@ geometry: &geom
   alias:
   - in code: ozone
     in file: O3
+  - in code: carbon_monoxide
+    in file: CO
+  - in code: nitrogen_dioxide
+    in file: NO2
+  - in code: sulfur_dioxide
+    in file: SO2
+  - in code: pm10
+    in file: dry_pm10_mass
+  - in code: pm2p5
+    in file: dry_pm2p5_mass
+  transform:
+  - variable: O3
     <<: *scalegas
     <<: *logtransform
     additive constant: *o3addconst
-  - in code: carbon_monoxide
-    in file: CO
+  - variable: CO
     <<: *scalegas
     <<: *logtransform
-  - in code: nitrogen_dioxide
-    in file: NO2
+  - variable: NO2
     <<: *scalegas
     <<: *logtransform
-  - in code: sulfur_dioxide
-    in file: SO2
+  - variable: SO2
     <<: *scalegas
     <<: *logtransform
-  - in code: pm10
-    in file: dry_pm10_mass
+  - variable: dry_pm10_mass
     <<: *logtransform
-  - in code: pm2p5
-    in file: dry_pm2p5_mass
+  - variable: dry_pm2p5_mass
     <<: *logtransform
   io:
     total number of levels: 24

--- a/test/monarch/testinput/letkf_nonlinear_4d.yaml
+++ b/test/monarch/testinput/letkf_nonlinear_4d.yaml
@@ -88,20 +88,25 @@ geometry: &geom
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
 #  - in code: carbon_monoxide
 #    in file: CO
-#    <<: *scalegas
 #  - in code: nitrogen_dioxide
 #    in file: NO2
-#    <<: *scalegas
 #  - in code: sulfur_dioxide
 #    in file: SO2
-#    <<: *scalegas
 #  - in code: pm10
 #    in file: dry_pm10_mass
 #  - in code: pm2p5
 #    in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+#  - variable: carbon_monoxide
+#    <<: *scalegas
+#  - variable: nitrogen_dioxide
+#    <<: *scalegas
+#  - variable: sulfur_dioxide
+#    <<: *scalegas
   io:
     total number of levels: 24
     initial date: 2022-06-30T12:00:00Z

--- a/test/monglob/testinput/dirac_3d.yaml
+++ b/test/monglob/testinput/dirac_3d.yaml
@@ -43,20 +43,25 @@ geometry:
   alias:
   - in code: ozone
     in file: O3
-    <<: *scalegas
   - in code: carbon_monoxide
     in file: CO
-    <<: *scalegas
   - in code: nitrogen_dioxide
     in file: NO2
-    <<: *scalegas
   - in code: sulfur_dioxide
     in file: SO2
-    <<: *scalegas
   - in code: pm10
     in file: dry_pm10_mass
   - in code: pm2p5
     in file: dry_pm2p5_mass
+  transform:
+  - variable: ozone
+    <<: *scalegas
+  - variable: carbon_monoxide
+    <<: *scalegas
+  - variable: nitrogen_dioxide
+    <<: *scalegas
+  - variable: sulfur_dioxide
+    <<: *scalegas
   io:
     total number of levels: 48
     initial date: 2017-12-16T12:00:00Z


### PR DESCRIPTION
This PR splits the content of Geometry `alias` into `alias` and `transform`. Parameter-specific methods are implemented to access the values, with a proper handling of default values (defined in a single location in `GeometryParameters`). This fixes #28 and simplifies the code.